### PR TITLE
Basic Github CI Action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,30 @@
+name: Continuous Integration
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  test:
+    name: Test
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - run: yarn install
+      - run: yarn build
+      - run: yarn test


### PR DESCRIPTION
* Run tests just to start off

Need the action in the default branch to get it to trigger.
Will be able to do automated docker builds next.
Just want to get `yarn test` in so long.

Partially resolves #1 