### PR TITLE
Automated Docker Builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,8 +38,8 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
 
-    # Don't build dependabot
-    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
+    # Don't build dependabot, don't build PRs
+    if: ${{ github.triggering_actor != 'dependabot[bot]' && github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v3
@@ -60,9 +60,8 @@ jobs:
         with:
           images: ${{ steps.login-ecr.outputs.registry }}/ssi-trust-registry
           tags: |
-            type=sha,prefix={{branch}}-,priority=601,enable=${{ github.event_name != 'pull_request' }}
+            type=sha,prefix={{branch}}-,priority=601
             type=ref,event=branch,priority=600
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 


### PR DESCRIPTION
Relates to #1 

Docker build pushes to `main` and PR's made against `main`.
Do not build anything triggered by Dependabot.
Enable multi-architecture builds. If builds performance is an issue this can easily be disabled.