### PR TITLE
Add MongoDB and Mongo Express to Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN yarn install --frozen-lockfile
 COPY --chown=1000:1000 . .
 RUN yarn build
 
+ENV URL=0.0.0.0
+ENV PORT=3000
+
 EXPOSE 3000
 
 ENTRYPOINT [ "tini", "--" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,70 +1,62 @@
-version: '3.8'
+version: '3'
 
 services:
-  ssi-trust-registry:
+  trust-registry:
     image: ${REGISTRY:-local}/ssi-trust-registry:${IMAGE_TAG:-latest}
-    container_name: ssi-trust-registry
+    container_name: trust-registry
     ports:
       - 3000:3000
     command:
       - yarn
       - dev
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
+      test: curl -f http://localhost:3000/health
       interval: 15s
       timeout: 5s
     environment:
-      - URL=0.0.0.0
-      - PORT=3000
+      URL: 0.0.0.0
+      PORT: 3000
     networks:
       - ssi-trust-registry
     depends_on:
-      postgres:
+      mongo:
         condition: service_healthy
-  postgres:
-    image: postgres:15
-    container_name: postgres
+  mongo:
+    image: mongo:6.0
+    container_name: mongo
     ports:
-      - 5432:5432
+      - 27017:27017
     environment:
-      - POSTGRES_USER=ssi-trust-registry
-      - POSTGRES_PASSWORD=ssi-trust-registry
-      - POSTGRES_DB=ssi-trust-registry
+      MONGO_INITDB_ROOT_USERNAME: mongo
+      MONGO_INITDB_ROOT_PASSWORD: mongo
+      MONGO_INITDB_DATABASE: trust-registry
     healthcheck:
-      test:
-        [
-          'CMD',
-          'pg_isready',
-          '--username',
-          'ssi-trust-registry',
-          '--dbname',
-          'ssi-trust-registry',
-        ]
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
       interval: 15s
       timeout: 5s
+      start_period: 5s
     networks:
       - ssi-trust-registry
     volumes:
-      - postgres:/var/lib/postgresql/data
-  pgadmin:
-    image: dpage/pgadmin4:7
-    container_name: pgadmin
+      - mongo:/data/db
+  mongo-express:
+    image: mongo-express:latest
+    container_name: mongo-express
     ports:
-      - 8080:80
+      - 8081:8081
     environment:
-      - PGADMIN_DEFAULT_EMAIL=pgadmin@example.com
-      - PGADMIN_DEFAULT_PASSWORD=pgadmin
+      ME_CONFIG_MONGODB_ENABLE_ADMIN: true
+      ME_CONFIG_MONGODB_ADMINUSERNAME: mongo
+      ME_CONFIG_MONGODB_ADMINPASSWORD: mongo
+      ME_CONFIG_MONGODB_URL: mongodb://mongo:mongo@mongo:27017
     networks:
       - ssi-trust-registry
-    volumes:
-      - pgadmin:/var/lib/pgadmin
     depends_on:
-      postgres:
+      mongo:
         condition: service_healthy
 
 volumes:
-  postgres:
-  pgadmin:
+  mongo:
 
 networks:
   ssi-trust-registry:


### PR DESCRIPTION
* Add `mongo` and `mongo-express` to Docker Compose
* Add `URL` and `PORT` environment variables to Dockerfile

Unfortunately, Tilt current does not respect `depends_on` config in Docker Compose
* tilt-dev/tilt#2239

So, if you're using Tilt, you may need to keep an eye on the startup logs of Mongo Express and (soon™) the SSI Trust Registry and click the restart button if they have issues connecting to MongoDB