### PR TITLE
Helm Chart and CD Workflow

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 build
+helm

--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: tailscale/github-action@main
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-          version: 1.46.0
+          version: 1.46.1
 
       - uses: docker/metadata-action@v4
         id: meta

--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -1,0 +1,95 @@
+name: Continuous Deployment
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    name: Deploy to EKS
+    concurrency:
+      group: dev
+      cancel-in-progress: false
+    environment:
+      name: dev
+      url: ${{ vars.PUBLIC_URL }}
+    permissions:
+      id-token: write
+      contents: read
+      checks: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: mdgreenwald/mozilla-sops-action@v1.4.1
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: af-south-1
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: github-cicd
+      - uses: unfor19/install-aws-cli-action@v1
+      - run: aws eks update-kubeconfig --name ${{ secrets.CLUSTER }}
+      - uses: azure/setup-kubectl@v3
+      - uses: azure/setup-helm@v3
+        with:
+          version: v3.12.2
+      - uses: tailscale/github-action@main
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          version: 1.46.0
+
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ssi-trust-registry
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=sha,prefix={{branch}}-,priority=601
+            type=ref,event=branch,priority=600
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Helmfile Diff
+        uses: helmfile/helmfile-action@v1.1.0 # https://github.com/helmfile/helmfile-action
+        with:
+          helmfile-args: |
+            diff \
+              --environment ${{ vars.ENVIRONMENT }} \
+              -f ./helm/trust-registry.yaml \
+              --set image.tag=${{ env.IMAGE_TAG }}
+          helm-plugins: |
+            https://github.com/databus23/helm-diff
+          helmfile-version: v0.155.1
+          helm-version: v3.12.2
+        env:
+          IMAGE_TAG: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+      - name: Wait for CI
+        if: github.event_name != 'workflow_dispatch'
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.sha }}
+          running-workflow-name: 'Deploy to EKS'
+          repo-token: ${{ github.token }}
+          wait-interval: 10
+      - name: Helmfile Apply
+        uses: helmfile/helmfile-action@v1.1.0
+        with:
+          helmfile-args: |
+            apply \
+              --environment ${{ vars.ENVIRONMENT }} \
+              -f ./helm/trust-registry.yaml \
+              --set image.tag=${{ env.IMAGE_TAG }} \
+              --skip-deps
+          helmfile-version: v0.155.1
+          helm-version: v3.12.2
+        env:
+          IMAGE_TAG: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+
+      - name: Test Health
+        run: curl --silent --show-error --fail ${{ vars.PUBLIC_URL }}/health
+      - name: Test Registry
+        run: curl --silent --show-error --fail ${{ vars.PUBLIC_URL }}/registry

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 build
+helm

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN yarn install --frozen-lockfile
 COPY --chown=1000:1000 . .
 RUN yarn build
 
-ENV URL=0.0.0.0
+ENV URL=http://0.0.0.0
 ENV PORT=3000
 
 EXPOSE 3000

--- a/helm/trust-registry.yaml
+++ b/helm/trust-registry.yaml
@@ -1,0 +1,23 @@
+environments:
+  dev:
+    values:
+      - namespace: trust-registry-dev
+---
+repositories:
+- name: bitnami
+  url: oci://registry-1.docker.io/bitnamicharts
+  oci: true
+---
+releases:
+- name: trust-registry
+  namespace: {{ .Values.namespace }}
+  chart: ./trust-registry
+  values:
+    - ./trust-registry/conf/{{ .Environment.Name }}/values.yaml
+---
+helmDefaults:
+  timeout: 60
+  wait: true
+  atomic: true
+  cleanupOnFail: true
+  createNamespace: false

--- a/helm/trust-registry/.helmignore
+++ b/helm/trust-registry/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/trust-registry/Chart.lock
+++ b/helm/trust-registry/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.4.0
+- name: mongodb
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 13.16.0
+digest: sha256:60cea9391f4e2020fa2bec4300c6ded93c377e57510b7bd36fa47966bc3d2ebf
+generated: "2023-07-25T11:28:19.132484+02:00"

--- a/helm/trust-registry/Chart.yaml
+++ b/helm/trust-registry/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: trust-registry
+description: A Helm chart to deploy the SSI Trust Registry in Kubernetes
+type: application
+version: 0.1.0
+
+keywords:
+  - ssi
+  - trust-registry
+  - did
+  - digital-identity
+
+maintainers:
+  - name: Robbie Blaine
+    email: robbie.blaine@didx.co.za
+
+dependencies:
+  # https://github.com/bitnami/charts/tree/main/bitnami/common
+  - name: common
+    version: 2.4.0
+    repository: oci://registry-1.docker.io/bitnamicharts
+  # https://github.com/bitnami/charts/tree/main/bitnami/mongodb
+  - name: mongodb
+    version: 13.16.0
+    repository: oci://registry-1.docker.io/bitnamicharts
+    alias: mongodb
+    condition: mongodb.enabled

--- a/helm/trust-registry/conf/dev/values.yaml
+++ b/helm/trust-registry/conf/dev/values.yaml
@@ -1,0 +1,76 @@
+replicaCount: 1
+
+image:
+  tag: latest
+
+initContainers:
+  - name: nc-mongo
+    image: busybox
+    imagePullPolicy: Always
+    command:
+      - sh
+      - -c
+      - |
+        until nc -w 3 -z ${MONGO_HOST} ${MONGO_PORT}; do
+          echo "Waiting for mongo to start..."
+          sleep 3
+        done
+    env:
+      - name: MONGO_HOST
+        valueFrom:
+          secretKeyRef:
+            name: mongo-connect
+            key: dbHost
+      - name: MONGO_PORT
+        valueFrom:
+          secretKeyRef:
+            name: mongo-connect
+            key: dbPort
+  - name: download-certs
+    image: busybox
+    imagePullPolicy: Always
+    command:
+      - sh
+      - -c
+      - |
+        wget -O /certs/global-bundle.pem \
+          https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+    volumeMounts:
+      - name: certs
+        mountPath: /certs
+extraVolumes:
+  - name: certs
+    emptyDir: {}
+extraVolumeMounts:
+  - name: certs
+    mountPath: /certs
+    readOnly: true
+
+extraEnvVars:
+  dbConnectionString:
+    valueFrom:
+      secretKeyRef:
+        name: mongo-connect
+        key: dbConnectionString
+
+ingress:
+  internal:
+    enabled: true
+    hosts:
+      - host: ssi-trust-registry.cloudapi.dev.didxtech.com
+  external:
+    enabled: true
+    hosts:
+      - host: ssi-trust-registry.cloudapi.dev.didxtech.com
+
+resources: {}
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/trust-registry/templates/_helpers.tpl
+++ b/helm/trust-registry/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "trust-registry.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "trust-registry.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "trust-registry.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "trust-registry.labels" -}}
+helm.sh/chart: {{ include "trust-registry.chart" . }}
+{{ include "trust-registry.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "trust-registry.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "trust-registry.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "trust-registry.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "trust-registry.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/trust-registry/templates/deployment.yaml
+++ b/helm/trust-registry/templates/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trust-registry.fullname" . }}
+  labels:
+    {{- include "trust-registry.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "trust-registry.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "trust-registry.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "trust-registry.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: trust-registry
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ include "trust-registry.fullname" . }}
+          {{- with .Values.extraEnvVars }}
+          env:
+            {{- range $k,$v := . }}
+            - name: {{ upper (snakecase $k) }}
+              {{- if typeIs "string" $v }}
+              value: {{ tpl $v $ }}
+              {{- else }}
+              {{- tpl (toYaml $v) $ | nindent 14 }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
+      {{- end }}

--- a/helm/trust-registry/templates/hpa.yaml
+++ b/helm/trust-registry/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "trust-registry.fullname" . }}
+  labels:
+    {{- include "trust-registry.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "trust-registry.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/trust-registry/templates/ingress.yaml
+++ b/helm/trust-registry/templates/ingress.yaml
@@ -1,0 +1,68 @@
+{{- range $key, $_ := .Values.ingress }}
+{{- if eq (tpl (toString .enabled) $) "true" }}
+{{- if $key }}
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  {{- if .name }}
+  name: {{ tpl .name $ }}
+  {{- else }}
+  name: {{ printf "%s-%s" (include "trust-registry.fullname" $) $key }}
+  {{- end }}
+  {{- with .namespace }}
+  namespace: {{ tpl . $ }}
+  {{- end }}
+  labels:
+    {{- include "trust-registry.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .tls }}
+  tls:
+  {{- range .tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | quote }}
+      {{- end }}
+      secretName: {{ include "common.tplvalues.render" ( dict "value" .secretName "context" $ ) }}
+  {{- end }}
+{{- end }}
+  ingressClassName: {{ .className }}
+  rules:
+  {{- range $rules := .hosts }}
+    - host: {{ tpl $rules.host $ | quote }}
+      http:
+        paths:
+      {{- if not $rules.paths }}
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ include "trust-registry.fullname" $ }}
+              port:
+                number: {{ $.Values.service.port }}
+      {{- else }}
+        {{- range $paths := $rules.paths }}
+        {{- if $paths.path }}
+        - path: {{ tpl $paths.path $ }}
+        {{- else }}
+        - path: /
+        {{- end }}
+          pathType: {{ default "Prefix" $paths.pathType }}
+          backend:
+            service:
+              name: {{ include "trust-registry.fullname" $ }}
+              port:
+                number: {{ $.Values.service.port }}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/helm/trust-registry/templates/secret.yaml
+++ b/helm/trust-registry/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "trust-registry.fullname" . }}
+  labels:
+    {{- include "trust-registry.labels" . | nindent 4 }}
+stringData:
+  {{- range $k,$v := .Values.config }}
+  {{ upper (snakecase $k) }}: {{ tpl (toString .) $ | quote }}
+  {{- end }}

--- a/helm/trust-registry/templates/service.yaml
+++ b/helm/trust-registry/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trust-registry.fullname" . }}
+  labels:
+    {{- include "trust-registry.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "trust-registry.selectorLabels" . | nindent 4 }}

--- a/helm/trust-registry/templates/serviceaccount.yaml
+++ b/helm/trust-registry/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "trust-registry.serviceAccountName" . }}
+  labels:
+    {{- include "trust-registry.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/trust-registry/templates/tests/test-connection.yaml
+++ b/helm/trust-registry/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "trust-registry.fullname" . }}-test-connection"
+  labels:
+    {{- include "trust-registry.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "trust-registry.fullname" . }}:{{ .Values.service.port }}/registry']
+  restartPolicy: Never

--- a/helm/trust-registry/values.yaml
+++ b/helm/trust-registry/values.yaml
@@ -1,0 +1,150 @@
+nameOverride: ""
+fullnameOverride: trust-registry
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/didx-xyz/ssi-trust-registry
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+imagePullSecrets: []
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+securityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  # capabilities:
+  #   drop:
+  #   - ALL
+
+config:
+  url: http://0.0.0.0
+  port: 3000
+  # dbConnectionString: mongodb://{{ .Values.db.user }}:{{ .Values.db.password }}@{{ .Values.db.host }}:{{ .Values.db.port }}/{{ .Values.db.opts }}
+  dbName: trust-registry
+
+db:
+  user: mongo
+  password: mongo
+  host: mongo
+  port: 27017
+  opts: ""
+
+extraEnvVars: {}
+  # foo: bar # -> FOO
+  # fooBaz: baz # -> FOO_BAZ
+  # dbConnectionString: # -> DB_CONNECTION_STRING
+  #   - valueFrom:
+  #       secretKeyRef:
+  #         name: mongo-connect
+  #         key: dbConnectionString
+
+initContainers:
+  - name: nc-mongo
+    image: busybox
+    imagePullPolicy: Always
+    command:
+      - sh
+      - -c
+      - |
+        until nc -w 3 -z {{ .Values.db.host }} {{ .Values.db.port }}; do
+          echo "Waiting for mongo to start..."
+          sleep 3
+        done
+  # - name: download-certs
+  #   image: busybox
+  #   imagePullPolicy: Always
+  #   command:
+  #     - sh
+  #     - -c
+  #     - |
+  #       wget -O /certs/global-bundle.pem \
+  #         https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+  #   volumeMounts:
+  #     - name: certs
+  #       mountPath: /certs
+extraVolumes: []
+  # - name: certs
+  #   emptyDir: {}
+extraVolumeMounts: []
+  # - name: certs
+  #   mountPath: /certs
+  #   readOnly: true
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  internal:
+    enabled: false
+    className: nginx-internal
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: trust-registry.example.com
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+  external:
+    enabled: false
+    className: nginx-external
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: trust-registry.example.com
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+mongodb:
+  # https://github.com/bitnami/charts/tree/main/bitnami/mongodb
+  enabled: false

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "rm -rf build && tsc",
-    "format:check": "prettier --check . --ignore-path .gitignore",
-    "format:update": "prettier --write . --ignore-path .gitignore",
+    "format:check": "prettier --check .",
+    "format:update": "prettier --write .",
     "lint": "eslint . --ignore-path .gitignore",
     "types:check": "tsc --noEmit",
     "validate": "yarn format:check && yarn lint && yarn types:check",


### PR DESCRIPTION
* Initial Helm and Continuous Deploy Workflow
* Update Prettier `--ignore-path`
  * Prettier uses `.gitignore` and `.prettierignore` by default
  * By specifying `--ignore-path .gitignore`, `.prettierignore` appears to
  be ignored, unlike `eslint --ignore-path` which is in addition to
  `.eslintignore`
  * Add `helm` to `.eslintignore` too

Relates to #1 