### PR TITLE
Add log metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ PORT=3000
 URL=http://localhost
 DB_CONNECTION_STRING=mongodb://localhost:4000
 DB_NAME=test_registry
+LOGGER_LOG_LEVEL=debug
+LOGGER_OUTPUT_FORMAT=json

--- a/src/database.ts
+++ b/src/database.ts
@@ -17,9 +17,7 @@ export async function connect(config: DbConfig) {
   await client.connect()
   const database = client.db(name)
   logger.info(`Connected to database '${name}'`)
-  logger.debug(
-    `Database stats: ${JSON.stringify(await database.stats(), null, 2)}`,
-  )
+  logger.debug(`Database stats:`, { metadata: await database.stats() })
   return database
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,7 +17,10 @@ const cliOutputFormat = combine(
   requestId(),
   printf((log) => {
     const requestId = log.requestId ? ` [requestId=${log.requestId}]` : ''
-    return `[${log.timestamp}] [${log.filename}] [${log.level}]${requestId}: ${log.message}`
+    const metadata = log.metadata
+      ? `\n${JSON.stringify(log.metadata, null, 2)}`
+      : ''
+    return `[${log.timestamp}] [${log.filename}] [${log.level}]${requestId}: ${log.message} ${metadata}`
   }),
   colorize({ all: true }),
 )

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,13 +8,9 @@ import { initRegistry, loadRegistry } from './registry'
 const logger = createLogger(__filename)
 
 async function main() {
-  logger.info(
-    `Starting app with the following config: ${JSON.stringify(
-      hideSecrets(config),
-      null,
-      2,
-    )}`,
-  )
+  logger.info(`Starting app with the following config`, {
+    metadata: hideSecrets(config),
+  })
 
   const database = await connect(config.db)
   initSubmissions(database)

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -40,9 +40,7 @@ export function errorHandler(
 ): void {
   logger.error('Error handler caught an error:', error, error.message)
   if (error instanceof ZodError) {
-    logger.error(
-      `Could not parse submission: \n ${JSON.stringify(error.issues, null, 2)}`,
-    )
+    logger.error(`Could not parse submission`, { metadata: error.issues })
     res.status(400).json({ error: error.issues })
   } else {
     res.status(500).json({ error: error.message || 'Unexpected error' })

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -37,26 +37,18 @@ export async function loadRegistry() {
     { id: 1 },
     { unique: true },
   )
-  logger.info(
-    `Index for registry document 'id' created: ${JSON.stringify(
-      createRegistryIdIndexResult,
-      null,
-      2,
-    )}`,
-  )
+  logger.info(`Index for registry document 'id' created:`, {
+    metadata: createRegistryIdIndexResult,
+  })
 
   try {
     const registryInsertionResult = await registryCollection.insertOne({
       id: 'registry-core-document',
       schemas: registry.schemas,
     })
-    logger.info(
-      `Registry has been stored: ${JSON.stringify(
-        registryInsertionResult,
-        null,
-        2,
-      )}`,
-    )
+    logger.info(`Registry has been stored`, {
+      metadata: registryInsertionResult,
+    })
   } catch (error) {
     if (
       error instanceof MongoServerError &&
@@ -73,25 +65,17 @@ export async function loadRegistry() {
     { id: 1 },
     { unique: true },
   )
-  logger.info(
-    `Index for subject document 'id' created: ${JSON.stringify(
-      createSubjectIdIndexResult,
-      null,
-      2,
-    )}`,
-  )
+  logger.info(`Index for subject document 'id' created`, {
+    metadata: createSubjectIdIndexResult,
+  })
 
   try {
     const subjectsInsertionResult = await subjectsCollection.insertMany(
       registry.entities,
     )
-    logger.info(
-      `Subjects has been stored: ${JSON.stringify(
-        subjectsInsertionResult,
-        null,
-        2,
-      )}`,
-    )
+    logger.info(`Subjects has been stored`, {
+      metadata: subjectsInsertionResult,
+    })
   } catch (error) {
     if (
       error instanceof MongoServerError &&

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,9 +69,7 @@ export function startServer(config: ServerConfig): Promise<Server> {
       disableInProduction,
       asyncHandler(async (req, res) => {
         const payload = req.body
-        logger.info(
-          `Processing submission:\n ${JSON.stringify(payload, null, 2)}`,
-        )
+        logger.info(`Processing submission:`, { metadata: payload })
         const submission = await addSubmission(payload)
         res.status(201).json(submission)
       }),

--- a/src/submission/mongoRepository.ts
+++ b/src/submission/mongoRepository.ts
@@ -23,13 +23,7 @@ export async function saveSubmission(submission: Submission) {
     ...submission,
   }
   const result = await submissionsCollection.insertOne(submissionData)
-  logger.info(
-    `Submission has been stored to database: ${JSON.stringify(
-      result,
-      null,
-      2,
-    )}`,
-  )
+  logger.info(`Submission has been stored to database`, { metadata: result })
   return result
 }
 


### PR DESCRIPTION
Allows to add log metadata to log additional information and pretty print them.

It's still not optimal, I would rather call the logger directly with the object being logged directly `logger.debug(`Database stats:`, await database.stats())`. However, that would require some additional workaround the winston API, so this solutions seems good enough for me for now.