### PR TITLE
refactor: log metadata argument

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -17,7 +17,7 @@ export async function connect(config: DbConfig) {
   await client.connect()
   const database = client.db(name)
   logger.info(`Connected to database '${name}'`)
-  logger.debug(`Database stats:`, { metadata: await database.stats() })
+  logger.debug(`Database stats:`, await database.stats())
   return database
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,10 +11,23 @@ const requestId = winston.format((info) => {
   return info
 })
 
-const jsonOutputFormat = combine(timestamp(), requestId(), json())
+const metadata = winston.format((info) => {
+  const additionalArgs = info[Symbol.for('splat')]
+  if (additionalArgs) {
+    if (additionalArgs.length === 1) {
+      info.metadata = additionalArgs[0]
+    } else {
+      info.metadata = additionalArgs
+    }
+  }
+  return info
+})
+
+const jsonOutputFormat = combine(timestamp(), requestId(), metadata(), json())
 const cliOutputFormat = combine(
   timestamp(),
   requestId(),
+  metadata(),
   printf((log) => {
     const requestId = log.requestId ? ` [requestId=${log.requestId}]` : ''
     const metadata = log.metadata

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,9 +8,7 @@ import { initRegistry, loadRegistry } from './registry'
 const logger = createLogger(__filename)
 
 async function main() {
-  logger.info(`Starting app with the following config`, {
-    metadata: hideSecrets(config),
-  })
+  logger.info(`Starting app with the following config`, hideSecrets(config))
 
   const database = await connect(config.db)
   initSubmissions(database)

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -40,7 +40,7 @@ export function errorHandler(
 ): void {
   logger.error('Error handler caught an error:', error, error.message)
   if (error instanceof ZodError) {
-    logger.error(`Could not parse submission`, { metadata: error.issues })
+    logger.error(`Could not parse submission`, error.issues)
     res.status(400).json({ error: error.issues })
   } else {
     res.status(500).json({ error: error.message || 'Unexpected error' })

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -37,18 +37,17 @@ export async function loadRegistry() {
     { id: 1 },
     { unique: true },
   )
-  logger.info(`Index for registry document 'id' created:`, {
-    metadata: createRegistryIdIndexResult,
-  })
+  logger.info(
+    `Index for registry document 'id' created:`,
+    createRegistryIdIndexResult,
+  )
 
   try {
     const registryInsertionResult = await registryCollection.insertOne({
       id: 'registry-core-document',
       schemas: registry.schemas,
     })
-    logger.info(`Registry has been stored`, {
-      metadata: registryInsertionResult,
-    })
+    logger.info(`Registry has been stored`, registryInsertionResult)
   } catch (error) {
     if (
       error instanceof MongoServerError &&
@@ -65,17 +64,16 @@ export async function loadRegistry() {
     { id: 1 },
     { unique: true },
   )
-  logger.info(`Index for subject document 'id' created`, {
-    metadata: createSubjectIdIndexResult,
-  })
+  logger.info(
+    `Index for subject document 'id' created`,
+    createSubjectIdIndexResult,
+  )
 
   try {
     const subjectsInsertionResult = await subjectsCollection.insertMany(
       registry.entities,
     )
-    logger.info(`Subjects has been stored`, {
-      metadata: subjectsInsertionResult,
-    })
+    logger.info(`Subjects has been stored`, subjectsInsertionResult)
   } catch (error) {
     if (
       error instanceof MongoServerError &&

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,7 +69,7 @@ export function startServer(config: ServerConfig): Promise<Server> {
       disableInProduction,
       asyncHandler(async (req, res) => {
         const payload = req.body
-        logger.info(`Processing submission:`, { metadata: payload })
+        logger.info(`Processing submission:`, payload)
         const submission = await addSubmission(payload)
         res.status(201).json(submission)
       }),

--- a/src/submission/mongoRepository.ts
+++ b/src/submission/mongoRepository.ts
@@ -23,7 +23,7 @@ export async function saveSubmission(submission: Submission) {
     ...submission,
   }
   const result = await submissionsCollection.insertOne(submissionData)
-  logger.info(`Submission has been stored to database`, { metadata: result })
+  logger.info(`Submission has been stored to database`, result)
   return result
 }
 


### PR DESCRIPTION
Allows metadata / other arguments to be logged directly, rather than wrapping with 

`{metadata:ARG}`