### PR TITLE
Disable `linux/arm64/v8` builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -71,8 +71,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
       - uses: docker/build-push-action@v4
         with:
-          # Only build `linux/amd64` on PR
-          platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64/v8' || 'linux/amd64' }}
+          platforms: linux/amd64 # linux/arm64/v8 is too slow to build (right now)
           # Don't push on PR
           push: ${{ github.event_name != 'pull_request' }}
           # Load into Docker daemon on PR


### PR DESCRIPTION
* It looks like the performance impact of `arm64` emulation for
multi-arch builds causes `yarn install` to time out.
* To resolve, will need to increase `network-timeout` to 200s, not
feasible in my opinion.