### PR TITLE
Add `node-gyp` to Docker build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
   gcc \
   make \
   python3
+RUN yarn global add node-gyp
 
 WORKDIR /app
 COPY yarn.lock package.json ./
@@ -36,6 +37,7 @@ COPY --from=builder /app /app
 USER 1000
 ENV URL=http://0.0.0.0
 ENV PORT=3000
+ENV NODE_ENV=${NODE_ENV}
 
 EXPOSE 3000
 


### PR DESCRIPTION
Resolves docker build error:
```
#13 [builder 5/7] RUN yarn install --frozen-lockfile
#13 0.274 yarn install v1.22.19
#13 0.371 [1/4] Resolving packages...
#13 0.638 [2/4] Fetching packages...
#13 12.03 [3/4] Linking dependencies...
#13 12.03 warning " > @aries-framework/askar@0.4.1" has unmet peer dependency "@hyperledger/aries-askar-shared@^0.1.0".
#13 12.03 warning "@aries-framework/askar > @aries-framework/core > @digitalcredentials/jsonld-signatures > isomorphic-webcrypto > expo-random@13.2.0" has unmet peer dependency "expo@*".
#13 12.03 warning "@aries-framework/askar > @aries-framework/core > @digitalcredentials/jsonld-signatures > isomorphic-webcrypto > react-native-securerandom@0.1.1" has unmet peer dependency "react-native@*".
#13 12.03 warning " > @aries-framework/indy-vdr@0.4.1" has unmet peer dependency "@hyperledger/indy-vdr-shared@^0.1.0".
#13 12.03 warning "ts-node-dev > ts-node@10.9.1" has unmet peer dependency "@types/node@*".
#13 16.70 [4/4] Building fresh packages...
#13 16.99 error /app/node_modules/ref-napi: Command failed.
#13 16.99 Exit code: 1
#13 16.99 Command: node-gyp-build
#13 16.99 Arguments: 
#13 16.99 Directory: /app/node_modules/ref-napi
#13 16.99 Output:
#13 16.99 node:events:495
#13 16.99       throw er; // Unhandled 'error' event
#13 16.99       ^
#13 16.99 
#13 16.99 Error: spawn node-gyp ENOENT
#13 16.99     at ChildProcess._handle.onexit (node:internal/child_process:284:19)
#13 16.99     at onErrorNT (node:internal/child_process:477:16)
#13 16.99     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
#13 16.99 Emitted 'error' event on ChildProcess instance at:
#13 16.99     at ChildProcess._handle.onexit (node:internal/child_process:290:12)
#13 16.99     at onErrorNT (node:internal/child_process:477:16)
#13 16.99     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
#13 16.99   errno: -2,
#13 16.99   code: 'ENOENT',
#13 16.99   syscall: 'spawn node-gyp',
#13 16.99   path: 'node-gyp',
#13 16.99   spawnargs: [ 'rebuild' ]
#13 16.99 }
#13 16.99 
#13 16.99 Node.js v18.18.0
#13 16.99 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
#13 ERROR: process "/bin/sh -c yarn install --frozen-lockfile" did not complete successfully: exit code: 1
------
 > [builder 5/7] RUN yarn install --frozen-lockfile:
16.99     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
16.99   errno: -2,
16.99   code: 'ENOENT',
16.99   syscall: 'spawn node-gyp',
16.99   path: 'node-gyp',
16.99   spawnargs: [ 'rebuild' ]
16.99 }
16.99 
16.99 Node.js v18.18.0
16.99 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
Dockerfile:17
--------------------
  15 |     ARG NODE_ENV=production
  16 |     ENV NODE_ENV=${NODE_ENV}
  17 | >>> RUN yarn install --frozen-lockfile
  18 |     
  19 |     COPY . .
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn install --frozen-lockfile" did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c yarn install --frozen-lockfile" did not complete successfully: exit code: 1
```