### PR TITLE
chore: set backend url on frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,38 @@ We require fully qualified schemas. You can find how the unqualified should be t
 - [Indy DID Method spec](https://hyperledger.github.io/indy-did-method/#schema)
 - [JavaScript implementation](https://gist.github.com/jakubkoci/26cb093d274bf61d982b4c56e05d9ebc)
 
-## Run
+## Development
 
-Build Docker image
+### Prerequisities
+
+- Node.js
+- Docker
+- Docker Compose (optional)
+
+### Run
+
+Start the database, you can use docker for that in the following way:
 
 ```sh
-docker build -t ssi-trust-registry .
+docker run --name mongo -p 4000:27017 -d mongo:6.0
+```
+
+You can change port but don't forget to update the `.env`.
+
+If you already have docker container, you can start/stop the container:
+
+```sh
+docker stop mongo
+```
+
+```sh
+docker start mongo
+```
+
+Start backend
+
+```sh
+cd packages/backend
 ```
 
 Create `.env`
@@ -29,13 +55,57 @@ Create `.env`
 cp .env.example .env
 ```
 
+Run the backend in dev mode
+
+```sh
+yarn dev
+```
+
+Start frontend
+
+```sh
+cd packages/frontend
+```
+
+Create `.env`
+
+```
+cp .env.example .env
+```
+
+Run the frontend in dev mode
+
+```sh
+yarn dev -p 3001
+```
+
+Start both
+
+### Run with Docker
+
+Build Docker image
+
+```sh
+docker build -t local/ssi-trust-registry .
+```
+
+Create common `.env` file from the `packages/frontend/.env` and `packages/backend/.env`:
+
+```sh
+cat packages/backend/.env > .env && cat packages/frontend/.env >> .env
+```
+
 Run Docker container
 
 ```sh
-docker run -d -p 3000:3000 --name ssi-trust-registry --env-file .env ssi-trust-registry
+docker run -d -p 3000:3000 -p 3001:3001 --name trust-registry --env-file .env local/ssi-trust-registry
 ```
 
-## Tests
+### Run with Docker Compose
+
+...
+
+### Run Tests
 
 There are integration tests that starts HTTP server and calls a database. We have to set some environment variables first. You can copy `.env.example` and update values according to the environment where your're running tests:
 
@@ -43,7 +113,7 @@ There are integration tests that starts HTTP server and calls a database. We hav
 cp .env.example .env.test
 ```
 
-Start the databse, you can use docker for that in the following way:
+Start the database, you can use docker for that in the following way:
 
 ```sh
 docker run --name mongo -p 4000:27017 -d mongo:6.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,8 @@ services:
       AUTH_ADMIN_PASSWORD_HASH: passwordhash
       FRONTEND_URL: http://localhost:3001
       SKIP_INITIAL_DATA_LOAD: true
+      LOGGER_LOG_LEVEL: debug
+      NEXT_PUBLIC_BACKEND_URL: http://localhost:3000
     networks:
       - ssi-trust-registry
     depends_on:

--- a/helm/trust-registry/Chart.lock
+++ b/helm/trust-registry/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.13.3
 - name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.2.0
-digest: sha256:92957dee305031bbd6b4e960416241c795578c39a0687c48bf864f4c2ec905f4
-generated: "2023-11-07T17:39:38.546882+02:00"
+  version: 14.4.2
+digest: sha256:6735081877a8f54386107fd44ad27e8e04c263f0c2cf0211d637de8f36e6e3ab
+generated: "2023-12-10T20:50:46.631989+02:00"

--- a/helm/trust-registry/Chart.yaml
+++ b/helm/trust-registry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trust-registry
 description: A Helm chart to deploy the SSI Trust Registry in Kubernetes
 type: application
-version: 0.1.6
+version: 0.2.0
 
 keywords:
   - ssi
@@ -21,7 +21,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
   # https://github.com/bitnami/charts/tree/main/bitnami/mongodb
   - name: mongodb
-    version: 14.2.0
+    version: 14.4.2
     repository: oci://registry-1.docker.io/bitnamicharts
     alias: mongodb
     condition: mongodb.enabled

--- a/helm/trust-registry/conf/dev/values.yaml
+++ b/helm/trust-registry/conf/dev/values.yaml
@@ -22,6 +22,10 @@ ingress:
     hosts:
       - host: ssi-trust-registry.cloudapi.dev.didxtech.com
 
+config:
+  frontendUrl: https://ssi-trust-registry.cloudapi.dev.didxtech.com
+  nextPublicBackendUrl: https://ssi-trust-registry.cloudapi.dev.didxtech.com
+
 resources: {}
   # requests:
   #   cpu: 100m

--- a/helm/trust-registry/conf/prod/values.yaml
+++ b/helm/trust-registry/conf/prod/values.yaml
@@ -22,6 +22,10 @@ ingress:
     hosts:
       - host: trust-registry.didx.co.za
 
+config:
+  frontendUrl: https://trust-registry.didx.co.za
+  nextPublicBackendUrl: https://trust-registry.didx.co.za
+
 resources: {}
   # requests:
   #   cpu: 100m

--- a/helm/trust-registry/templates/deployment.yaml
+++ b/helm/trust-registry/templates/deployment.yaml
@@ -45,8 +45,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
+            - name: backend
               containerPort: {{ .Values.config.port }}
+              protocol: TCP
+            - name: frontend
+              containerPort: 3001
               protocol: TCP
           envFrom:
             - secretRef:
@@ -66,15 +69,15 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: http
+              port: backend
           readinessProbe:
             httpGet:
               path: /health
-              port: http
+              port: backend
           startupProbe:
             httpGet:
               path: /health
-              port: http
+              port: backend
             failureThreshold: 30
             periodSeconds: 10
           resources:

--- a/helm/trust-registry/templates/ingress.yaml
+++ b/helm/trust-registry/templates/ingress.yaml
@@ -47,7 +47,14 @@ spec:
             service:
               name: {{ include "trust-registry.fullname" $ }}
               port:
-                number: {{ $.Values.service.port }}
+                number: {{ $.Values.service.frontend.port }}
+        - path: /api
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ include "trust-registry.fullname" $ }}
+              port:
+                number: {{ $.Values.service.backend.port }}
       {{- else }}
         {{- range $paths := $rules.paths }}
         {{- if $paths.path }}
@@ -60,7 +67,7 @@ spec:
             service:
               name: {{ include "trust-registry.fullname" $ }}
               port:
-                number: {{ default $.Values.service.port $paths.port }}
+                number: {{ int64 (tpl (toString $paths.port) $) }}
         {{- end -}}
       {{- end -}}
     {{- end -}}

--- a/helm/trust-registry/templates/service.yaml
+++ b/helm/trust-registry/templates/service.yaml
@@ -7,9 +7,13 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+    - name: frontend
+      port: {{ .Values.service.frontend.port }}
+      targetPort: {{ default .Values.service.frontend.port .Values.service.frontend.targetPort }}
+      protocol: {{ default "TCP" .Values.service.frontend.protocol }}
+    - name: backend
+      port: {{ .Values.service.backend.port }}
+      targetPort: {{ default .Values.service.backend.port .Values.service.backend.targetPort }}
+      protocol: {{ default "TCP" .Values.service.backend.protocol }}
   selector:
     {{- include "trust-registry.selectorLabels" . | nindent 4 }}

--- a/helm/trust-registry/values.yaml
+++ b/helm/trust-registry/values.yaml
@@ -25,8 +25,8 @@ deploymentLabels:
   tags.datadoghq.com/service: '{{ include "trust-registry.fullname" . }}'
   tags.datadoghq.com/version: '{{ .Values.image.tag }}'
 podAnnotations:
-  # gcr.io/datadoghq/dd-lib-js-init
-  admission.datadoghq.com/js-lib.version: v4.18.0
+  # https://gcr.io/datadoghq/dd-lib-js-init
+  admission.datadoghq.com/js-lib.version: v4.20.0
 podLabels:
   # tags.datadoghq.com/env: <env>
   tags.datadoghq.com/service: '{{ include "trust-registry.fullname" . }}'
@@ -45,6 +45,7 @@ securityContext:
 
 config:
   frontendUrl: http://localhost:3001
+  nextPublicBackendUrl: https://localhost:3000
   url: http://0.0.0.0
   port: 3000
   # dbConnectionString: mongodb://{{ .Values.db.user }}:{{ .Values.db.password }}@{{ .Values.db.host }}:{{ .Values.db.port }}/{{ .Values.db.opts }}
@@ -128,7 +129,10 @@ extraVolumeMounts:
 
 service:
   type: ClusterIP
-  port: 3000
+  backend:
+    port: 3000
+  frontend:
+    port: 3001
 
 ingress:
   internal:
@@ -139,9 +143,6 @@ ingress:
       # kubernetes.io/tls-acme: "true"
     hosts:
       - host: trust-registry.example.com
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:
@@ -154,9 +155,6 @@ ingress:
       # kubernetes.io/tls-acme: "true"
     hosts:
       - host: trust-registry.example.com
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_BACKEND_URL=http://localhost:3000

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -1,6 +1,6 @@
 import { BaseError } from 'make-error'
 
-export const backendUrl = 'http://localhost:3000'
+export const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
 
 export interface LoginForm {
   email: string

--- a/packages/frontend/src/app/invitations/new/components/InviteForm.tsx
+++ b/packages/frontend/src/app/invitations/new/components/InviteForm.tsx
@@ -87,7 +87,7 @@ export function InviteForm() {
 async function invite({ emailAddress }: { emailAddress: string }) {
   return betterFetch(
     'POST',
-    'http://localhost:3000/api/invitations',
+    `${backendUrl}/api/invitations`,
     {},
     { emailAddress },
   )

--- a/packages/frontend/src/common/components/navigation/Header.tsx
+++ b/packages/frontend/src/common/components/navigation/Header.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { NavigationItem } from '@/common/components/navigation/NavigationItem'
-import { betterFetch, getUser, logOut } from '@/api'
+import { backendUrl, betterFetch, getUser, logOut } from '@/api'
 import { usePathname } from 'next/navigation'
 import { useRouter } from 'next/navigation'
 
@@ -101,7 +101,7 @@ async function getPendingSubmissionsCount(): Promise<number> {
   try {
     const submissions = await betterFetch(
       'GET',
-      'http://localhost:3000/api/submissions',
+      `${backendUrl}/api/submissions`,
       {},
     )
     return submissions.filter(


### PR DESCRIPTION
@rblaine95 I added a new env `NEXT_PUBLIC_BACKEND_URL`, that's for the frontend app to know what's the backend endpoint. There is also `FRONTEND_URL` env for backend to know what's the frontend to correctly set CORS.

Now, could you please create a new domain for the frontend server and set those two variables properly?

It should be something like
```
FRONTEND_URL=https://web.ssi-trust-registry.cloudapi.dev.didxtech.com/
NEXT_PUBLIC_BACKEND_URL=https://ssi-trust-registry.cloudapi.dev.didxtech.com/
```

That assumes we preserve the current backend address. Maybe we can change both of them in the following way:

```
FRONTEND_URL=https://web-trust-registry.cloudapi.dev.didxtech.com/
NEXT_PUBLIC_BACKEND_URL=https://api-trust-registry.cloudapi.dev.didxtech.com/
```

In the end, it's mainly up to you, how you want to deploy it.


